### PR TITLE
fix: prevent panic when JSON_REPORT missing, add retry logic

### DIFF
--- a/l2lib.go
+++ b/l2lib.go
@@ -57,6 +57,8 @@ const (
 	L2ContainerMemReq              = "100M"
 	// ptpIfIndent defines the indentation level for PtpIf detailed output
 	ptpIfIndent = 6
+	// L2DiscoveryRetries is the number of retries for getL2Disc
+	L2DiscoveryRetries = 3
 )
 
 type L2DaemonsetMode int64
@@ -270,9 +272,20 @@ func (config *L2DiscoveryConfig) DiscoverL2Connectivity(ptpInterfacesOnly, allIF
 	if err != nil {
 		return fmt.Errorf("could not get l2 discovery pods, err=%s", err)
 	}
-	err = config.getL2Disc(ptpInterfacesOnly)
+	// Retry getL2Disc up to L2DiscoveryRetries times
+	for attempt := 1; attempt <= L2DiscoveryRetries; attempt++ {
+		err = config.getL2Disc(ptpInterfacesOnly)
+		if err == nil {
+			break
+		}
+		logrus.Warnf("attempt %d/%d: error getting l2 discovery data, err=%s", attempt, L2DiscoveryRetries, err)
+		if attempt < L2DiscoveryRetries {
+			logrus.Infof("waiting %v before retry...", L2DiscoveryDuration)
+			time.Sleep(L2DiscoveryDuration)
+		}
+	}
 	if err != nil {
-		logrus.Errorf("error getting l2 discovery data, err=%s", err)
+		logrus.Errorf("failed to get l2 discovery data after %d attempts, err=%s", L2DiscoveryRetries, err)
 	}
 	// Delete L2 discovery daemonset
 	if config.L2DsMode == Managed {
@@ -319,6 +332,9 @@ func (config *L2DiscoveryConfig) getL2Disc(ptpInterfacesOnly bool) error {
 	for _, k := range keys {
 		podLogs, _ := pods.GetLog(config.L2DiscoveryPods[k], config.L2DiscoveryPods[k].Spec.Containers[0].Name)
 		indexReport := strings.LastIndex(podLogs, "JSON_REPORT")
+		if indexReport == -1 {
+			return fmt.Errorf("no JSON_REPORT found in pod logs for pod %s on node %s", config.L2DiscoveryPods[k].Name, config.L2DiscoveryPods[k].Spec.NodeName)
+		}
 		report := strings.Split(strings.Split(podLogs[indexReport:], `\n`)[0], "JSON_REPORT")[1]
 		var discDataPerNode map[string]map[string]*exports.Neighbors
 		if err := json.Unmarshal([]byte(report), &discDataPerNode); err != nil {


### PR DESCRIPTION
- Add bounds check for strings.LastIndex to prevent slice bounds panic when JSON_REPORT is not found in pod logs
- Add retry mechanism for getL2Disc with 3 attempts and 15s wait between retries to handle transient failures during L2 discovery