### PR TITLE
Fix remaining CI issues

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -50,9 +50,9 @@ jobs:
         uses: mfinelli/setup-shfmt@031e887e39d899d773a7e9b6dd6472c2c23ff50d # v3.0.1
 
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64
+          version: v2.1
           args: --timeout 10m0s
 
       - name: Checkmake

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,50 +1,7 @@
-linters-settings:
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 60
-    statements: 45
-  goconst:
-    min-len: 4
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - whyNoLint
-  gocyclo:
-    min-complexity: 20
-  mnd:
-    # do not include the "operation" and "assign"
-    checks:
-      - argument
-      - case
-      - condition
-      - return
-  govet:
-    settings:
-      printf:
-        funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-  lll:
-    line-length: 250
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # do not require an explanation for nolint directives
-    require-specific: true # require nolint directives to be specific about which linter is being skipped
-  exhaustive:
-    default-signifies-exhaustive: true
+version: "2"
+
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - dogsled
@@ -54,43 +11,68 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-    - mnd
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
+    - mnd
     - nolintlint
     - rowserrcheck
-    - staticcheck
-    - stylecheck
+    - staticcheck  # includes gosimple and stylecheck in v2
     - unconvert
     - unparam
     - whitespace
-  # do not enable:
-  # - asciicheck
-  # - depguard
-  # - dupl
-  # - gochecknoglobals
-  # - gochecknoinits
-  # - gocognit
-  # - godot
-  # - godox
-  # - goerr113
-  # - maligned
-  # - nakedret
-  # - nestif
-  # - noctx
-  # - prealloc
-  # - revive
-  # - exportloopref
-  # - structcheck
-  # - testpackage
-  # - wsl
+  settings:
+    dupl:
+      threshold: 100
+    funlen:
+      lines: 60
+      statements: 45
+    goconst:
+      min-len: 4
+      min-occurrences: 2
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      disabled-checks:
+        - whyNoLint
+    gocyclo:
+      min-complexity: 20
+    mnd:
+      # do not include the "operation" and "assign"
+      checks:
+        - argument
+        - case
+        - condition
+        - return
+    govet:
+      settings:
+        printf:
+          funcs:
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+    lll:
+      line-length: 250
+    nolintlint:
+      allow-unused: false # report any unused nolint directives
+      require-explanation: false # do not require an explanation for nolint directives
+      require-specific: true # require nolint directives to be specific about which linter is being skipped
+    exhaustive:
+      default-signifies-exhaustive: true
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
 issues:
   exclude-dirs:
     - cmd/l2discovery
@@ -122,8 +104,3 @@ issues:
     - linters:
         - gocritic
       text: "unnecessaryDefer:"
-    # Ignore static strings in tests
-
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_VERSION=v1.64.5
+GOLANGCI_VERSION=v2.1.6
 GO_PACKAGES=$(shell go list ./... | grep -v vendor)
 
 .PHONY: all clean test build build-l2discovery lint install-lint vet fmt image launch
@@ -14,9 +14,9 @@ fmt:
 lint:
 	golangci-lint run
 
-# Install golangci-lint	
+# Install golangci-lint v2
 install-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin ${GOLANGCI_VERSION}
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_VERSION}
 
 vet:
 	go vet ${GO_PACKAGES}

--- a/cmd/l2dump/main.go
+++ b/cmd/l2dump/main.go
@@ -36,7 +36,9 @@ func getGraph(data l2lib.L2Info) {
 		if err := mainGraph.Close(); err != nil {
 			logrus.Fatal(err)
 		}
-		g.Close()
+		if err := g.Close(); err != nil {
+			logrus.Fatal(err)
+		}
 	}()
 	nodes := make(map[string]bool)
 	for _, lan := range *data.GetLANs() {
@@ -81,7 +83,7 @@ func getGraph(data l2lib.L2Info) {
 			if err != nil {
 				logrus.Fatal(err)
 			}
-			nodes[aIf.IfClusterIndex].SetLabel(aIf.IfClusterIndex.InterfaceName)
+			nodes[aIf.IfClusterIndex].SetLabel(aIf.InterfaceName)
 			nodes[aIf.IfClusterIndex].SetColorScheme("svg")
 			nodes[aIf.IfClusterIndex].SetStyle("filled")
 			nodes[aIf.IfClusterIndex].SetColor(aColor)

--- a/l2lib.go
+++ b/l2lib.go
@@ -399,7 +399,7 @@ func (config *L2DiscoveryConfig) getInterfacesReceivingPTP(ptpInterfacesOnly boo
 			aPortGettingPTP := &exports.PtpIf{}
 			aPortGettingPTP.Iface = ifaceMap.Local
 			aPortGettingPTP.NodeName = config.L2DiscoveryPods[k].Spec.NodeName
-			aPortGettingPTP.InterfaceName = aPortGettingPTP.Iface.IfName
+			aPortGettingPTP.InterfaceName = aPortGettingPTP.IfName
 
 			if ptpInterfacesOnly &&
 				(strings.Contains(aPortGettingPTP.IfPci.Description, "Virtual") ||

--- a/pkg/graphsolver/graphsolver.go
+++ b/pkg/graphsolver/graphsolver.go
@@ -302,7 +302,7 @@ func SameLan2Wrapper(config exports.L2Info, if1, if2 int) bool {
 
 // Determines if 2 interfaces (ports) belong to the same NIC
 func SameNic(ifaceName1, ifaceName2 *exports.PtpIf) bool {
-	if ifaceName1.IfClusterIndex.NodeName != ifaceName2.IfClusterIndex.NodeName {
+	if ifaceName1.NodeName != ifaceName2.NodeName {
 		return false
 	}
 	return ifaceName1.IfPci.Device != "" && ifaceName1.IfPci.Device == ifaceName2.IfPci.Device

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -54,6 +54,7 @@ supports-priv-flags: no`,
 	}
 }
 
+//nolint:funlen
 func TestParseLspci(t *testing.T) {
 	type args struct {
 		output string

--- a/pkg/pods/pods.go
+++ b/pkg/pods/pods.go
@@ -16,7 +16,9 @@ func GetLog(p *corev1.Pod, containerName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer log.Close()
+	defer func() {
+		_ = log.Close()
+	}()
 
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, log)


### PR DESCRIPTION
- Update golangci-lint-action to v7 with golangci-lint v2.1
- Migrate .golangci.yml to v2 format:
  - Add version: "2" header
  - Change disable-all to linters.default: none
  - Move settings under linters.settings
  - Move gofmt/goimports to formatters section
  - Remove deprecated gosimple/stylecheck (now in staticcheck)
- Update Makefile to install golangci-lint v2.1.6 via go install
- Fix errcheck violations: check Close() return values
- Fix staticcheck QF1008: simplify embedded field selectors
- Add nolint:funlen directive for long test function