### PR TITLE
ci: use latest golangci-lint for Go 1.25 compatibility

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1
+          version: latest
           args: --timeout 10m0s
 
       - name: Checkmake

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_VERSION=v2.1.6
+GOLANGCI_VERSION=latest
 GO_PACKAGES=$(shell go list ./... | grep -v vendor)
 
 .PHONY: all clean test build build-l2discovery lint install-lint vet fmt image launch

--- a/pkg/graphsolver/graphsolver.go
+++ b/pkg/graphsolver/graphsolver.go
@@ -373,6 +373,7 @@ func applyStep(config exports.L2Info, step [][]int, combinations []int) bool {
 			negate = test[negationIdx] == Negative
 		}
 
+		//nolint:gosec // G602: slice indices are controlled by step definition and param count in test[1]
 		switch test[1] {
 		case int(NoParam):
 			stepResult = AlgoCode0[test[0]]()


### PR DESCRIPTION
- Change golangci-lint version to 'latest' in workflow and Makefile to ensure compatibility with Go 1.25 (fixed v2.1.6 was built with Go 1.24)
- Add nolint:gosec directive for G602 false positive in graphsolver.go (slice indices are controlled by step definition)