### PR TITLE
ci: align linter versions using make lint in CI

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -49,11 +49,11 @@ jobs:
       - name: Install Shfmt
         uses: mfinelli/setup-shfmt@031e887e39d899d773a7e9b6dd6472c2c23ff50d # v3.0.1
 
+      - name: Install golangci-lint
+        run: make install-lint
+
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@v7
-        with:
-          version: latest
-          args: --timeout 10m0s
+        run: make lint
 
       - name: Checkmake
         run: checkmake --config=.checkmake Makefile

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,36 @@ linters:
     - unconvert
     - unparam
     - whitespace
+  exclusions:
+    paths:
+      - cmd/l2discovery
+    rules:
+      # Ignore magic numbers, inline strings and function length in tests.
+      - path: _test\.go
+        linters:
+          - mnd
+          - goconst
+          - funlen
+      - path: config/config.go
+        linters:
+          - mnd
+      - path: _scaling.go
+        linters:
+          - gocritic
+      - path: hugepages.go
+        linters:
+          - mnd
+      - path: scheduling.go
+        linters:
+          - mnd
+      # Ignore line length for string assignments (do not try and wrap regex definitions)
+      - linters:
+          - lll
+        source: "^(.*= (\".*\"|`.*`))$"
+      # https://github.com/go-critic/go-critic/issues/926
+      - linters:
+          - gocritic
+        text: "unnecessaryDefer:"
   settings:
     dupl:
       threshold: 100
@@ -72,35 +102,3 @@ formatters:
   enable:
     - gofmt
     - goimports
-
-issues:
-  exclude-dirs:
-    - cmd/l2discovery
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    # Ignore magic numbers, inline strings and function length in tests.
-    - path: _test\.go
-      linters:
-        - mnd
-        - goconst
-        - funlen
-    - path: config/config.go
-      linters:
-        - mnd
-    - path: _scaling.go
-      linters:
-        - gocritic
-    - path: hugepages.go
-      linters:
-        - mnd
-    - path: scheduling.go
-      linters:
-        - mnd
-    # Ignore line length for string assignments (do not try and wrap regex definitions)
-    - linters:
-        - lll
-      source: "^(.*= (\".*\"|`.*`))$"
-    # https://github.com/go-critic/go-critic/issues/926
-    - linters:
-        - gocritic
-      text: "unnecessaryDefer:"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_VERSION=latest
+GOLANGCI_VERSION=v2.8.0
 GO_PACKAGES=$(shell go list ./... | grep -v vendor)
 
 .PHONY: all clean test build build-l2discovery lint install-lint vet fmt image launch

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -53,8 +53,6 @@ supports-priv-flags: no`,
 		})
 	}
 }
-
-//nolint:funlen
 func TestParseLspci(t *testing.T) {
 	type args struct {
 		output string


### PR DESCRIPTION
- Replace golangci-lint-action with make install-lint + make lint to ensure CI uses the same version as local development
- Pin golangci-lint to v2.8.0 in Makefile
- Migrate .golangci.yml to v2.8.0 schema:
  - Move issues.exclude-dirs to linters.exclusions.paths
  - Move issues.exclude-rules to linters.exclusions.rules
- Remove redundant nolint:funlen directive from parser_test.go