### PR TITLE
fix: handle pods.GetLog error explicitly in getL2Disc

### DIFF
--- a/l2lib.go
+++ b/l2lib.go
@@ -330,7 +330,10 @@ func (config *L2DiscoveryConfig) getL2Disc(ptpInterfacesOnly bool) error {
 	sort.Strings(keys)
 
 	for _, k := range keys {
-		podLogs, _ := pods.GetLog(config.L2DiscoveryPods[k], config.L2DiscoveryPods[k].Spec.Containers[0].Name)
+		podLogs, err := pods.GetLog(config.L2DiscoveryPods[k], config.L2DiscoveryPods[k].Spec.Containers[0].Name)
+		if err != nil {
+			return fmt.Errorf("failed to get logs for pod %s on node %s: %w", config.L2DiscoveryPods[k].Name, config.L2DiscoveryPods[k].Spec.NodeName, err)
+		}
 		indexReport := strings.LastIndex(podLogs, "JSON_REPORT")
 		if indexReport == -1 {
 			return fmt.Errorf("no JSON_REPORT found in pod logs for pod %s on node %s", config.L2DiscoveryPods[k].Name, config.L2DiscoveryPods[k].Spec.NodeName)


### PR DESCRIPTION
Previously the error was ignored, which could lead to misleading 'no JSON_REPORT found' errors when the actual issue was a failure to fetch pod logs.