### PR TITLE
Enhance PTP capabilities in l2discovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi:latest
-RUN dnf -y --disableplugin=subscription-manager install iputils iproute ethtool pciutils
 RUN dnf -y --disableplugin=subscription-manager remove python3-setuptools
+RUN dnf -y --disableplugin=subscription-manager install iputils iproute ethtool pciutils
 COPY l2discovery-linux-amd64 /usr/bin
 COPY l2discovery-linux-arm64 /usr/bin
 RUN \

--- a/cmd/l2discovery/main.go
+++ b/cmd/l2discovery/main.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -487,6 +488,8 @@ func getIfs(cfg config, cmdPrefix string) (macs map[string]*exports.Iface, macsE
 		if err != nil {
 			return macs, macsExist, fmt.Errorf("could not get PTP capabilities info err: %s", err)
 		}
+		ptpCaps.HasPtpPins = hasPtpPins(aIfRaw.Ifname, ptpCaps.PhcIndex, cmdPrefix)
+		ptpCaps.GnssDevice = getGnssDevice(aIfRaw.Ifname, cmdPrefix)
 		aIface := exports.Iface{
 			IfName:      aIfRaw.Ifname,
 			IfMac:       exports.Mac{Data: strings.ToUpper(aIfRaw.Address)},
@@ -560,6 +563,8 @@ func getPtpCaps(
 		hwRxString         = "hardware-receive"
 		hwRawClock         = "hardware-raw-clock"
 	)
+	aPTPCaps.PhcIndex = -1
+
 	aCommand := cmdPrefix + ethtoolBaseCommand + ifaceName
 	stdout, stderr, err := runCmd(aCommand)
 	if err != nil || stderr != "" {
@@ -583,5 +588,61 @@ func getPtpCaps(
 			aPTPCaps.HwRawClock = aString == hwRawClock
 		}
 	}
+
+	phcRe := regexp.MustCompile(`(?m)PTP Hardware Clock:\s+(\S+)`)
+	if matches := phcRe.FindStringSubmatch(stdout); len(matches) > 1 {
+		if !strings.EqualFold(matches[1], "none") {
+			if idx, parseErr := strconv.Atoi(matches[1]); parseErr == nil {
+				aPTPCaps.PhcIndex = idx
+			}
+		}
+	}
+
 	return aPTPCaps, nil
+}
+
+func hasPtpPins(ifaceName string, phcIndex int, cmdPrefix string) bool {
+	if phcIndex < 0 {
+		return false
+	}
+	path := fmt.Sprintf("/sys/class/net/%s/device/ptp/ptp%d/pins", ifaceName, phcIndex)
+	cmd := fmt.Sprintf("%sls -d %s 2>/dev/null", cmdPrefix, path)
+	stdout, _, err := runLocalCommand(cmd)
+	return err == nil && strings.TrimSpace(stdout) != ""
+}
+
+func getGnssDevice(ifaceName, cmdPrefix string) string {
+	path := fmt.Sprintf("/sys/class/net/%s/device/gnss", ifaceName)
+	cmd := fmt.Sprintf("%sls %s 2>/dev/null", cmdPrefix, path)
+	stdout, _, err := runLocalCommand(cmd)
+	if err != nil || strings.TrimSpace(stdout) == "" {
+		return ""
+	}
+	for _, dev := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		if dev != "" && checkGNRMC(dev, cmdPrefix) {
+			return dev
+		}
+	}
+	return ""
+}
+
+func checkGNRMC(deviceName, cmdPrefix string) bool {
+	cmd := fmt.Sprintf("%shead -n 1 /dev/%s", cmdPrefix, strings.TrimSpace(deviceName))
+	stdout, _, err := runLocalCommand(cmd)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.Contains(line, "GNRMC") {
+			parts := strings.Split(line, ",")
+			if len(parts) > 1 {
+				timeVal := parts[1]
+				formattedTime := time.Now().UTC().Format("150405") + ".00"
+				if strings.EqualFold(timeVal, formattedTime) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/cmd/l2discovery/main.go
+++ b/cmd/l2discovery/main.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -488,8 +489,15 @@ func getIfs(cfg config, cmdPrefix string) (macs map[string]*exports.Iface, macsE
 		if err != nil {
 			return macs, macsExist, fmt.Errorf("could not get PTP capabilities info err: %s", err)
 		}
-		ptpCaps.HasPtpPins = hasPtpPins(aIfRaw.Ifname, ptpCaps.PhcIndex, cmdPrefix)
-		ptpCaps.GnssDevice = getGnssDevice(aIfRaw.Ifname, cmdPrefix)
+		hostPrefix := ""
+		if strings.Contains(cmdPrefix, "/host") {
+			hostPrefix = "/host"
+		} else if _, statErr := os.Stat("/host/sys"); statErr == nil {
+			hostPrefix = "/host"
+		}
+		ptpCaps.HasPtpPins = hasPtpPins(aIfRaw.Ifname, ptpCaps.PhcIndex, hostPrefix)
+		pciBusAddr := address.Device + "." + address.Function
+		ptpCaps.GnssDevice = getGnssDevice(aIfRaw.Ifname, pciBusAddr, hostPrefix)
 		aIface := exports.Iface{
 			IfName:      aIfRaw.Ifname,
 			IfMac:       exports.Mac{Data: strings.ToUpper(aIfRaw.Address)},
@@ -598,36 +606,60 @@ func getPtpCaps(
 		}
 	}
 
+	if aPTPCaps.PhcIndex < 0 {
+		phcRe2 := regexp.MustCompile(`(?m)Hardware timestamp provider index:\s+(\S+)`)
+		if matches := phcRe2.FindStringSubmatch(stdout); len(matches) > 1 {
+			if !strings.EqualFold(matches[1], "none") {
+				if idx, parseErr := strconv.Atoi(matches[1]); parseErr == nil {
+					aPTPCaps.PhcIndex = idx
+				}
+			}
+		}
+	}
+
 	return aPTPCaps, nil
 }
 
-func hasPtpPins(ifaceName string, phcIndex int, cmdPrefix string) bool {
+func hasPtpPins(ifaceName string, phcIndex int, hostPrefix string) bool {
 	if phcIndex < 0 {
 		return false
 	}
-	path := fmt.Sprintf("/sys/class/net/%s/device/ptp/ptp%d/pins", ifaceName, phcIndex)
-	cmd := fmt.Sprintf("%sls -d %s 2>/dev/null", cmdPrefix, path)
-	stdout, _, err := runLocalCommand(cmd)
-	return err == nil && strings.TrimSpace(stdout) != ""
-}
-
-func getGnssDevice(ifaceName, cmdPrefix string) string {
-	path := fmt.Sprintf("/sys/class/net/%s/device/gnss", ifaceName)
-	cmd := fmt.Sprintf("%sls %s 2>/dev/null", cmdPrefix, path)
+	path := fmt.Sprintf("%s/sys/class/ptp/ptp%d/pins", hostPrefix, phcIndex)
+	devPath := fmt.Sprintf("%s/sys/class/net/%s/device/ptp/ptp%d/pins", hostPrefix, ifaceName, phcIndex)
+	cmd := fmt.Sprintf("ls -d %s %s 2>/dev/null | head -1", path, devPath)
 	stdout, _, err := runLocalCommand(cmd)
 	if err != nil || strings.TrimSpace(stdout) == "" {
-		return ""
+		return false
 	}
-	for _, dev := range strings.Split(strings.TrimSpace(stdout), "\n") {
-		if dev != "" && checkGNRMC(dev, cmdPrefix) {
-			return dev
+	pinsDir := strings.TrimSpace(stdout)
+	listCmd := fmt.Sprintf("ls %s 2>/dev/null", pinsDir)
+	listOut, _, listErr := runLocalCommand(listCmd)
+	return listErr == nil && strings.TrimSpace(listOut) != ""
+}
+
+func getGnssDevice(ifaceName, pciBusAddr, hostPrefix string) string {
+	paths := []string{
+		fmt.Sprintf("%s/sys/class/net/%s/device/gnss", hostPrefix, ifaceName),
+		fmt.Sprintf("%s/sys/bus/pci/devices/%s/gnss", hostPrefix, pciBusAddr),
+	}
+	for _, path := range paths {
+		cmd := fmt.Sprintf("ls %s 2>/dev/null", path)
+		stdout, _, err := runLocalCommand(cmd)
+		if err != nil || strings.TrimSpace(stdout) == "" {
+			continue
+		}
+		for _, dev := range strings.Split(strings.TrimSpace(stdout), "\n") {
+			if dev != "" && checkGNRMC(dev, hostPrefix) {
+				return dev
+			}
 		}
 	}
 	return ""
 }
 
-func checkGNRMC(deviceName, cmdPrefix string) bool {
-	cmd := fmt.Sprintf("%shead -n 1 /dev/%s", cmdPrefix, strings.TrimSpace(deviceName))
+func checkGNRMC(deviceName, hostPrefix string) bool {
+	devPath := fmt.Sprintf("%s/dev/%s", hostPrefix, strings.TrimSpace(deviceName))
+	cmd := fmt.Sprintf("timeout 3 head -n 1 %s", devPath)
 	stdout, _, err := runLocalCommand(cmd)
 	if err != nil {
 		return false
@@ -635,12 +667,8 @@ func checkGNRMC(deviceName, cmdPrefix string) bool {
 	for _, line := range strings.Split(stdout, "\n") {
 		if strings.Contains(line, "GNRMC") {
 			parts := strings.Split(line, ",")
-			if len(parts) > 1 {
-				timeVal := parts[1]
-				formattedTime := time.Now().UTC().Format("150405") + ".00"
-				if strings.EqualFold(timeVal, formattedTime) {
-					return true
-				}
+			if len(parts) > 2 && parts[2] == "A" {
+				return true
 			}
 		}
 	}

--- a/exports/exports.go
+++ b/exports/exports.go
@@ -56,10 +56,14 @@ func (pci PCIAddress) String() string {
 
 type PTPCaps struct {
 	HwRx, HwTx, HwRawClock bool
+	PhcIndex               int
+	HasPtpPins             bool
+	GnssDevice             string
 }
 
 func (caps PTPCaps) String() string {
-	return fmt.Sprintf("HwRx:%t HwTx:%t HwRawClock:%t", caps.HwRx, caps.HwTx, caps.HwRawClock)
+	return fmt.Sprintf("HwRx:%t HwTx:%t HwRawClock:%t PhcIndex:%d HasPtpPins:%t GnssDevice:%s",
+		caps.HwRx, caps.HwTx, caps.HwRawClock, caps.PhcIndex, caps.HasPtpPins, caps.GnssDevice)
 }
 
 type Iface struct {

--- a/pkg/graphsolver/graphsolver.go
+++ b/pkg/graphsolver/graphsolver.go
@@ -359,14 +359,36 @@ func SameNicWrapper(config exports.L2Info, if1, if2 int) bool {
 	return SameNic(config.GetPtpIfList()[if1], config.GetPtpIfList()[if2])
 }
 
-// IsWpcNic determines if the NIC is intel WPC NIC
+// IsWpcNic determines if the NIC is an intel WPC NIC by checking subsystem,
+// valid PHC index, and PTP pins support.
 func IsWpcNic(ifaceName1 *exports.PtpIf) bool {
-	return strings.Contains(ifaceName1.IfPci.Subsystem, WPCNICSubsystemID)
+	if !strings.Contains(ifaceName1.IfPci.Subsystem, WPCNICSubsystemID) {
+		return false
+	}
+	if ifaceName1.IfPTPCaps.PhcIndex < 0 {
+		return false
+	}
+	return ifaceName1.IfPTPCaps.HasPtpPins
 }
 
-// IsWpcNicWrapper is the wrapper for IsWpcNic
+// IsWPCNicWrapper checks if the interface is a WPC NIC, considering that PTP pins
+// may be exposed through any sibling interface sharing the same PHC on the same node.
 func IsWPCNicWrapper(config exports.L2Info, if1 int) bool {
-	return IsWpcNic(config.GetPtpIfList()[if1])
+	ptpIf := config.GetPtpIfList()[if1]
+	if !strings.Contains(ptpIf.IfPci.Subsystem, WPCNICSubsystemID) {
+		return false
+	}
+	if ptpIf.IfPTPCaps.PhcIndex < 0 {
+		return false
+	}
+	for _, peer := range config.GetPtpIfList() {
+		if peer.NodeName == ptpIf.NodeName &&
+			peer.IfPTPCaps.PhcIndex == ptpIf.IfPTPCaps.PhcIndex &&
+			peer.IfPTPCaps.HasPtpPins {
+			return true
+		}
+	}
+	return false
 }
 
 // ClockClassLessThan checks if any PTP Announce received on the interface

--- a/pkg/graphsolver/graphsolver.go
+++ b/pkg/graphsolver/graphsolver.go
@@ -359,34 +359,47 @@ func SameNicWrapper(config exports.L2Info, if1, if2 int) bool {
 	return SameNic(config.GetPtpIfList()[if1], config.GetPtpIfList()[if2])
 }
 
-// IsWpcNic determines if the NIC is an intel WPC NIC by checking subsystem,
-// valid PHC index, and PTP pins support.
+// IsWpcNic determines if the NIC is a WPC NIC by checking subsystem,
+// valid PHC index, and PTP pins support. Also accepts NICs that have
+// both PTP pins and a GNSS device (covers netdevsim WPC emulation).
 func IsWpcNic(ifaceName1 *exports.PtpIf) bool {
-	if !strings.Contains(ifaceName1.IfPci.Subsystem, WPCNICSubsystemID) {
-		return false
-	}
 	if ifaceName1.IfPTPCaps.PhcIndex < 0 {
 		return false
 	}
-	return ifaceName1.IfPTPCaps.HasPtpPins
+	hasWpcSubsystem := strings.Contains(ifaceName1.IfPci.Subsystem, WPCNICSubsystemID)
+	hasWpcCaps := ifaceName1.IfPTPCaps.HasPtpPins && ifaceName1.IfPTPCaps.GnssDevice != ""
+	if !hasWpcSubsystem && !hasWpcCaps {
+		return false
+	}
+	return true
 }
 
 // IsWPCNicWrapper checks if the interface is a WPC NIC, considering that PTP pins
-// may be exposed through any sibling interface sharing the same PHC on the same node.
+// and GNSS devices may be exposed through any sibling interface sharing the same
+// PHC on the same node.
 func IsWPCNicWrapper(config exports.L2Info, if1 int) bool {
 	ptpIf := config.GetPtpIfList()[if1]
-	if !strings.Contains(ptpIf.IfPci.Subsystem, WPCNICSubsystemID) {
-		return false
-	}
 	if ptpIf.IfPTPCaps.PhcIndex < 0 {
 		return false
 	}
+	hasWpcSubsystem := strings.Contains(ptpIf.IfPci.Subsystem, WPCNICSubsystemID)
+	var hasPins, hasGnss bool
 	for _, peer := range config.GetPtpIfList() {
 		if peer.NodeName == ptpIf.NodeName &&
-			peer.IfPTPCaps.PhcIndex == ptpIf.IfPTPCaps.PhcIndex &&
-			peer.IfPTPCaps.HasPtpPins {
-			return true
+			peer.IfPTPCaps.PhcIndex == ptpIf.IfPTPCaps.PhcIndex {
+			if peer.IfPTPCaps.HasPtpPins {
+				hasPins = true
+			}
+			if peer.IfPTPCaps.GnssDevice != "" {
+				hasGnss = true
+			}
 		}
+	}
+	if hasWpcSubsystem && hasPins {
+		return true
+	}
+	if hasPins && hasGnss {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
- Added support for retrieving PTP pins and GNSS device information in the getIfs function.
- Updated PTPCaps struct to include PhcIndex, HasPtpPins, and GnssDevice fields.
- Improved IsWpcNic and IsWPCNicWrapper functions to check for PTP pins and valid PHC index.

These changes enhance the PTP capabilities detection and provide more detailed interface information.

Assisted-By: Cursor